### PR TITLE
Fix navigation paths for Windows

### DIFF
--- a/examples/generic/build-permalinks.js
+++ b/examples/generic/build-permalinks.js
@@ -72,7 +72,7 @@ var relativePathHelper = function(current, target) {
     current = path.normalize(current).slice(0);
     target = path.normalize(target).slice(0);
     current = path.dirname(current);
-    return path.relative(current, target);
+    return path.relative(current, target).replace(/\\/g, '/');
 };
 
 Handlebars.registerHelper('relative_path', relativePathHelper);

--- a/examples/generic/build.js
+++ b/examples/generic/build.js
@@ -64,7 +64,7 @@ var relativePathHelper = function(current, target) {
     current = path.normalize(current).slice(0);
     target = path.normalize(target).slice(0);
     current = path.dirname(current);
-    return path.relative(current, target);
+    return path.relative(current, target).replace(/\\/g, '/');
 };
 
 Handlebars.registerHelper('relative_path', relativePathHelper);

--- a/lib/index.js
+++ b/lib/index.js
@@ -467,7 +467,7 @@ var replaceDirsSeparator = function(navFiles) {
 * @param {Object} files - metalsmith files plugin param
 * @return {Array} nav tree
 */
-var getNav = function(navName, config, files, settings){
+var getNav = function(navName, config, navFiles, settings){
     config = merge(NAV_CONFIG_DEFAULT, config);
 
     var sortByNameFirst             = config.sortByNameFirst,
@@ -483,13 +483,10 @@ var getNav = function(navName, config, files, settings){
     settings = settings || {};
 
     var permalinks = settings.permalinks;
-    var navFiles = files;
-
-    navFiles = replaceDirsSeparator(navFiles);
 
     // filter to files that match the filterProperty and filterValue
     if(filterProperty){
-        navFiles = filterFiles(files, filterProperty, filterValue);
+        navFiles = filterFiles(navFiles, filterProperty, filterValue);
     }
 
     var paths = Object.keys(navFiles).map(function(path) {
@@ -498,7 +495,7 @@ var getNav = function(navName, config, files, settings){
 
     var nodes = pathsToTree(paths);
 
-    nodes = addNodeMetadata(nodes, files, sortBy);
+    nodes = addNodeMetadata(nodes, navFiles, sortBy);
 
     if(mergeMatchingFilesAndDirs){
         nodes = mergeFileDirs(nodes);
@@ -515,7 +512,7 @@ var getNav = function(navName, config, files, settings){
         nodes = sortNodes(nodes, sortBy);
     }
 
-    nodes = setFileObjectReferences(nodes, files, pathProperty, childrenProperty, navName);
+    nodes = setFileObjectReferences(nodes, navFiles, pathProperty, childrenProperty, navName);
 
     if(breadcrumbProperty){
         nodes = setBreadcrumbs(nodes, breadcrumbProperty);
@@ -564,8 +561,12 @@ var plugin = function plugin(navConfigs, navSettings){
 
             var config = navConfigs[key];
 
+            // replace backslash with slash for proper web navigation
+            var navFiles = files;
+            navFiles = replaceDirsSeparator(navFiles);
+
             // get processed nav
-            var nav = getNav(key, config, files, navSettings);
+            var nav = getNav(key, config, navFiles, navSettings);
 
             // apply permalinks if set in settings
             if(permalinks){


### PR DESCRIPTION
There was a function for replacing backslash separators (replaceDirsSeparator) with slash but after it was called the original files variable was used in several functions.

Now replaceDirsSeparator is called before getNav and the variable navFiles is passed to getNav.

The relativePathHelper functions in the example are also transformed. 
